### PR TITLE
add get_log function

### DIFF
--- a/src/gym_trading_env/environments.py
+++ b/src/gym_trading_env/environments.py
@@ -259,6 +259,15 @@ class TradingEnv(gym.Env):
             for metric in self.log_metrics:
                 text += f"   |   {metric['name']} : {metric['function'](self.historical_info)}"
             print(text)
+
+    def get_log(self):
+        market_return = self.historical_info["data_close", -1] / self.historical_info["data_close", 0] -1
+        portfolio_return = self.historical_info["portfolio_valuation", -1] / self.historical_info["portfolio_valuation", 0] -1
+        out_logs = {"market_return": market_return, "portfolio_return": portfolio_return}
+        for metric in self.log_metrics:
+            out_logs[metric['name']] = metric['function'](self.historical_info)
+        return out_logs
+
     def save_for_render(self, dir = "render_logs"):
         assert "open" in self.df and "high" in self.df and "low" in self.df and "close" in self.df, "Your DataFrame needs to contain columns : open, high, low, close to render !"
         columns = list(set(self.historical_info.columns) - set([f"date_{col}" for col in self._info_columns]))


### PR DESCRIPTION
Hey, 
I wanted to start by saying that I think your project is great, and I'm excited to see the backtesting features you're planning to add. I was wondering if you had considered including a function to retrieve metrics that could be easily logged to platforms like wandb or TensorBoard. It seems like this could be a useful addition for users who want to track and analyze the performance of their trading strategies.





