### PR TITLE
docs: remove duplicated docs for param

### DIFF
--- a/src/gym_trading_env/environments.py
+++ b/src/gym_trading_env/environments.py
@@ -68,9 +68,6 @@ class TradingEnv(gym.Env):
     :param max_episode_duration: If a integer value is used, each episode will be truncated after reaching the desired max duration in steps (by returning `truncated` as `True`). When using a max duration, each episode will start at a random starting point.
     :type max_episode_duration: optional - int or 'max'
 
-    :param max_episode_duration: If a integer value is used, each episode will be truncated after reaching the desired max duration in steps (by returning `truncated` as `True`). When using a max duration, each episode will start at a random starting point.
-    :type max_episode_duration: optional - int or 'max'
-
     :param verbose: If 0, no log is outputted. If 1, the env send episode result logs.
     :type verbose: optional - int
     


### PR DESCRIPTION
I saw the duplicated param docs while reading it from the [Environment Quick Summary](https://gym-trading-env.readthedocs.io/en/latest/environment_desc.html) page

<img width="1160" alt="image" src="https://github.com/ClementPerroud/Gym-Trading-Env/assets/86024/946e1b54-851b-4a62-a71f-814e3bdb46b2">
