### PR TITLE
Stop treating warnings as errors

### DIFF
--- a/src/gym_trading_env/environments.py
+++ b/src/gym_trading_env/environments.py
@@ -11,8 +11,7 @@ from .utils.history import History
 from .utils.portfolio import Portfolio, TargetPortfolio
 
 import tempfile, os
-import warnings
-warnings.filterwarnings("error")
+
 
 def basic_reward_function(history : History):
     return np.log(history["portfolio_valuation", -1] / history["portfolio_valuation", -2])


### PR DESCRIPTION
This is a pretty strong choice for a library. It's simply impiossible to deal with that in projects with multiple large dependencies. There's always going to be a deprecation warning somewhere